### PR TITLE
Revert links to magenta.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midcamp/hatter",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "The Hatter style-guide for MidCamp.org",
   "repository": "https://github.com/backlineint/hatter-v2.git",
   "publishConfig": {

--- a/source/scss/_init.scss
+++ b/source/scss/_init.scss
@@ -122,7 +122,7 @@ $focus-outline-med-blue: #3195ff;
 $text-color: $gray-dark;
 $background-color: $white;
 /* Link (a:) */
-$link-color: $blue-dark;
+$link-color: $magenta;
 $link-hover: $magenta;
 /* Blockquote*/
 $blockquote-color: $purple;


### PR DESCRIPTION
![Image from iOS (1)](https://user-images.githubusercontent.com/238201/69300331-7ca12b00-0bd8-11ea-915d-a9a3b750f7fa.jpg)

Links don't look good in dark-blue. Let's just revert them to magenta for now.

![midcamplinks](https://user-images.githubusercontent.com/238201/69300425-cbe75b80-0bd8-11ea-8165-4761ef18dcb7.gif)
